### PR TITLE
完善逻辑，增加type数组内引用类型解析

### DIFF
--- a/jest/tstype.ts
+++ b/jest/tstype.ts
@@ -30,3 +30,5 @@ type Type_11 = { name: Label };
 type Type_12 = AAA[];
 
 type Type_13 = {};
+
+type Type_14 = { id: string; name: string; children: AAA[] }[];

--- a/src/__tests__/__snapshots__/generic.test.ts.snap
+++ b/src/__tests__/__snapshots__/generic.test.ts.snap
@@ -202,14 +202,6 @@ Object {
         "value",
       ],
       "type": "object",
-      "typeParams": Object {
-        "0": Object {
-          "default": Object {
-            "type": "string",
-          },
-          "name": "T",
-        },
-      },
     },
   },
   "properties": Object {
@@ -243,21 +235,5 @@ Object {
     "value",
   ],
   "type": "object",
-  "typeParams": Object {
-    "0": Object {
-      "default": Object {
-        "$realRef": "Generic_8",
-        "$ref": "#Generic_8<string>",
-        "items": Object {
-          "extraParams": Array [
-            Object {
-              "type": "string",
-            },
-          ],
-        },
-      },
-      "name": "T",
-    },
-  },
 }
 `;

--- a/src/__tests__/__snapshots__/tstype.test.ts.snap
+++ b/src/__tests__/__snapshots__/tstype.test.ts.snap
@@ -235,6 +235,48 @@ Object {
 }
 `;
 
+exports[`type类型_数组_2 1`] = `
+Object {
+  "definitions": Object {
+    "AAA": Object {
+      "additionalProperties": false,
+      "properties": Object {
+        "other1": Object {
+          "type": "string",
+        },
+      },
+      "required": Array [
+        "other1",
+      ],
+      "type": "object",
+    },
+  },
+  "items": Object {
+    "properties": Object {
+      "children": Object {
+        "items": Object {
+          "$ref": "#/definitions/AAA",
+        },
+        "type": "array",
+      },
+      "id": Object {
+        "type": "string",
+      },
+      "name": Object {
+        "type": "string",
+      },
+    },
+    "required": Array [
+      "id",
+      "name",
+      "children",
+    ],
+    "type": "object",
+  },
+  "type": "array",
+}
+`;
+
 exports[`type类型_空对象_1 1`] = `
 Object {
   "type": "object",

--- a/src/__tests__/tstype.test.ts
+++ b/src/__tests__/tstype.test.ts
@@ -49,3 +49,8 @@ test('type类型_数组_1', () => {
 test('type类型_空对象_1', () => {
   expect(getSchema('Type_13')).toMatchSnapshot();
 });
+
+test('type类型_数组_2', () => {
+  expect(getSchema('Type_14')).toMatchSnapshot();
+});
+

--- a/src/get-jsonschema-from-data.ts
+++ b/src/get-jsonschema-from-data.ts
@@ -240,7 +240,7 @@ export default class genTypeSchema extends typescriptToFileDatas {
           const item = result.properties[key] || {};
           if (item.$ref) {
             const name = item.$ref.replace('#', '');
-            const ref = fileJson[name];
+            let ref = fileJson[name];
             if (ref && ref.$realRef && ref.$ref && ref.items && ref.items.extraParams) {
               item.$ref = ref.$ref;
               item.$realRef = ref.$realRef;
@@ -534,7 +534,12 @@ export default class genTypeSchema extends typescriptToFileDatas {
         res && Object.assign(item, res);
       } else if (typeof item === 'object') {
         delete item.items;
-        attrCommonHandle(item);
+        let handle = true;
+        const $refKey = item.$ref.replace(/#(\/definitions\/)?/, '');
+        if (typeJson.definitions && Object.keys(typeJson.definitions[$refKey] || {}).length) {
+          handle = false;
+        }
+        attrCommonHandle(item, handle);
       }
     };
 
@@ -567,7 +572,7 @@ export default class genTypeSchema extends typescriptToFileDatas {
       const { definitions, $ref } = typeJson_;
       if ($ref && definitions) {
         const key = $ref.replace(/#\/definitions\//, '');
-        const res = definitions[key];
+        const res = definitions[key] || { definitions: {} };
         delete typeJson_.definitions[key];
         res.definitions = { ...res.definitions, ...typeJson_.definitions };
         typeJson = res;


### PR DESCRIPTION
1.新增type = {a:string,b:AAA}[]类型的解析
2.返回的jsonschema删除typeParams参数，保证格式正确
3.避免definitions被覆盖