### PR TITLE
docs(readme): fix jump link between different languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Test](https://github.com/yunke-yunfly/fast-typescript-to-jsonschema/workflows/Test/badge.svg)
 [![codecov](https://codecov.io/gh/yunke-yunfly/fast-typescript-to-jsonschema/branch/master/graph/badge.svg)](https://app.codecov.io/gh/yunke-yunfly/fast-typescript-to-jsonschema)
 
-English | [简体中文](./README.md)
+English | [简体中文](./README.zh-cn.md)
 
 a tool generate json schema from typescript.
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -4,7 +4,7 @@
 ![Test](https://github.com/yunke-yunfly/fast-typescript-to-jsonschema/workflows/Test/badge.svg)
 [![codecov](https://codecov.io/gh/yunke-yunfly/fast-typescript-to-jsonschema/branch/master/graph/badge.svg)](https://app.codecov.io/gh/yunke-yunfly/fast-typescript-to-jsonschema)
 
-中文 | [English](./README.en-US.md)
+简体中文 | [English](./README.md)
 
 生成typescript类型的jsonschema数据
 


### PR DESCRIPTION
This pr is created to fix some jump errors in readme.md and readme.zh-cn.md caused by [#15](https://github.com/yunke-yunfly/fast-typescript-to-jsonschema/pull/15/commits/df98316506277468909d8c44b2f8473db3cab13c).